### PR TITLE
Fixes keystonejs#2362 - Passport provider hostname/callback issue.

### DIFF
--- a/.changeset/little-walls-love.md
+++ b/.changeset/little-walls-love.md
@@ -1,0 +1,10 @@
+---
+'@keystonejs/auth-passport': patch
+---
+
+Fixes #2362 - Passport Auth. 
+
+Implements solution by @HackerYunen, adds Hostname for callback inside passport. 
+Either this is needed, or we need to split the middleware config to add/remove this before/after route instantiation as it uses this config to 
+    1.) create the callback route, and 
+    2.) passes this to the provider.

--- a/packages/auth-passport/README.md
+++ b/packages/auth-passport/README.md
@@ -123,6 +123,7 @@ const googleStrategy = keystone.createAuthStrategy({
     appSecret: '<Your Google App Secret>',
     loginPath: '/auth/google',
     callbackPath: '/auth/google/callback',
+    callbackHost: 'http://www.example.com',
 
     // Once a user is found/created and successfully matched to the
     // googleId, they are authenticated, and the token is returned here.

--- a/packages/auth-passport/lib/Passport.js
+++ b/packages/auth-passport/lib/Passport.js
@@ -36,6 +36,7 @@ class PassportAuthStrategy {
     assert(!!config.appSecret, 'Must provide `config.appSecret` option.');
     assert(!!config.loginPath, 'Must provide `config.loginPath` option.');
     assert(!!config.idField, 'Must provide `config.idField` option.');
+    assert(!!config.callbackHost, 'Must provide `config.callbackHost` option.');
     assert(
       typeof config.cookieSecret === 'undefined',
       'The `cookieSecret` config option for `PassportAuthStrategy` has been moved to the `Keystone` constructor: `new Keystone({ cookieSecret: "abc" })`.'
@@ -89,6 +90,7 @@ class PassportAuthStrategy {
     this._loginPath = config.loginPath;
     this._loginPathMiddleware = config.loginPathMiddleware || ((req, res, next) => next());
     this._callbackPath = config.callbackPath;
+    this._callbackHost = config.callbackHost;
     this._callbackPathMiddleware = config.callbackPathMiddleware || ((req, res, next) => next());
     this._passportScope = config.scope || [];
     this._resolveCreateData = config.resolveCreateData || (({ createData }) => createData);
@@ -390,7 +392,7 @@ class PassportAuthStrategy {
       {
         clientID: this._serviceAppId,
         clientSecret: this._serviceAppSecret,
-        callbackURL: this._callbackPath,
+        callbackURL: this._callbackHost + this._callbackPath,
         passReqToCallback: true,
         ...strategyConfig,
       },


### PR DESCRIPTION
Fixes keystonejs#2362

Implements solution by @HackerYunen, adds Hostname for callback inside passport.
Either this is needed, or we need to split the middleware config to add/remove this before/after route instantiation as it uses this config to
    1.) create the callback route, and
    2.) passes this to the provider.

Additionally, adds supporting documentation in [/packages/auth-passport/README.md](/packages/auth-passport/README.md)
